### PR TITLE
vendor/bundle を指定する必要ないし、カレントパスなら docker-compose で渡せているので不要

### DIFF
--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -10,6 +10,4 @@ RUN mkdir /myapp
 WORKDIR /myapp
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock
-RUN bundle install --path vendor/bundle
-
-COPY . /myapp
+RUN bundle install


### PR DESCRIPTION
主題の通り。
些細ではあるけど、無駄になっている設定があったので修正。
